### PR TITLE
feat: endpoint option for hybris backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Hybris works with a list of objects with the properties id and catalog and requi
 ```json
 {
   "hybrisUrl": "{URL of your hybris api}",
+  "hybrisUrl": "{Endpoint for you hybris api (defaults to /rest/v2)}",
   "backend": "hybris",
   "currency": "{Currency of your products defaults to USD}",
   "catalogs": [

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Hybris works with a list of objects with the properties id and catalog and requi
 ```json
 {
   "hybrisUrl": "{URL of your hybris api}",
-  "hybrisUrl": "{Endpoint for you hybris api (defaults to /rest/v2)}",
+  "hybrisEndpoint": "{Endpoint for your hybris api (defaults to /rest/v2)}",
   "backend": "hybris",
   "currency": "{Currency of your products defaults to USD}",
   "catalogs": [

--- a/src/backends/Hybris.js
+++ b/src/backends/Hybris.js
@@ -3,10 +3,16 @@ import { ProductSelectorError } from '../ProductSelectorError';
 
 export class Hybris {
 
-  constructor({ hybrisUrl } = {}) {
+  constructor({ hybrisUrl, hybrisEndpoint } = {}) {
     this.hybrisUrl = hybrisUrl;
 
-    this.productService = new ProductService(hybrisUrl, '/rest/v2', null);
+    if (!hybrisEndpoint) {
+      hybrisEndpoint = '/rest/v2';
+    }
+
+    this.hybrisEndpoint = hybrisEndpoint;
+
+    this.productService = new ProductService(hybrisUrl, hybrisEndpoint, null);
   }
 
   async getItems(state, filterIds) {

--- a/src/backends/__tests__/Hybris.spec.js
+++ b/src/backends/__tests__/Hybris.spec.js
@@ -4,6 +4,13 @@ import {ProductSelectorError} from "../../ProductSelectorError";
 
 describe('Hybris', () => {
   it('should create an instance of ProductService', () => {
+    const params = {hybrisUrl: 'http://test.com', hybrisEndpoint: '/endpoint/v2'};
+    const hybris = new Hybris(params);
+
+    expect(hybris.productService).toEqual(new ProductService(params.hybrisUrl, '/endpoint/v2', null));
+  });
+
+  it('should create an instance of ProductService, where a missing endpoint is replaced by /rest/v2', () => {
     const params = {hybrisUrl: 'http://test.com'};
     const hybris = new Hybris(params);
 

--- a/src/store/backend/__tests__/backend.actions.spec.js
+++ b/src/store/backend/__tests__/backend.actions.spec.js
@@ -44,7 +44,10 @@ describe('backend actions', () => {
     const params = {
       backend: 'hybris',
       hybrisUrl: '/hybris',
-      catalogs: [{ id: '123', name: 'electronics' }],
+      hybrisEndpoint: '/occ/v2',
+      catalogs: [
+        {id: '123', name: 'electronics'}
+      ]
     };
     const store = mockStore({ params });
 


### PR DESCRIPTION
The endpoint that the `ycommercewebservices` endpoint is on might be different between hybris instances, depending on configuration. I've seen a few setups with `/occ/v2`, so it was worth adding this option just to support those cases.

The tests have been updated to check the correct endpoint is passed for both the default behaviour, and when `hybrisEndpoint` is specified in params. The hybris example has also been updated in the readme.