### PR TITLE
feat(sfcc): add sfcc cors backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The IDs of each product selected are added to the content as an array of strings
 
 ![](/screenshot.png?raw=true)
 
-The extension requires the use of the [sfcc-product-search-proxy)](https://github.com/amplience/sfcc-product-search-proxy) to work around CORS issues when calling the SFCC data endpoint. It is not needed when using with Hybris or Commercetools.
+The default SFCC backend requires the use of the [sfcc-product-search-proxy)](https://github.com/amplience/sfcc-product-search-proxy) to work around CORS issues when calling the SFCC data endpoint. It is not needed when using with Hybris or Commercetools, or using the `sfcc-cors` backend with the proper configuration.
 
 ## Installation Parameters
 
@@ -22,7 +22,50 @@ The extension requires the use of the [sfcc-product-search-proxy)](https://githu
 | noItemsText | No items selected. | Placeholder text to display when no items are selected. | false
 | searchPlaceholderText  | Search  | Placeholder text to show in the search box.  | false 
 
-### SFCC
+
+### SFCC (cors)
+
+To use this mode, your SFCC instance must be configured to allow the origin of the hosted extension for the provided client, and you must use at least version 21.10 of the api. The extension works with 'list of text' properties and supports the following parameters:
+
+```json
+{
+  "backend": "sfcc-cors",
+  "sfccUrl": "{The URL of the SFCC instance}",
+  "authSecret": "{The SFCC OAuth client secret}",
+  "authClientId": "{The SFCC OAuth client ID}",
+  "siteId": "{The ID of the site containing products in SFCC}"
+}
+```
+
+#### Example Snippet
+
+```json
+{
+  "product selector": {
+    "title": "Product Selector",
+    "description": "description",
+    "type": "array",
+    "minItems": 3,
+    "maxItems": 10,
+    "items": {
+      "type": "string"
+    },
+    "ui:extension": {
+      "url": "https://product-selector.amplience.com",
+      "height": 208,
+      "params": {
+        "backend": "sfcc-cors",
+        "sfccUrl": "https://sandbox.demandware.net",
+        "authSecret": "aa1111AAAAAA1",
+        "authClientId": "11111111-1111-1111-1111-111111111111",
+        "siteId": "TestSite"
+      }
+    }
+  }
+}
+```
+
+### SFCC (proxy)
 
 The extension works with 'list of text' properties and supports the following parameters:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-extension-product-selector",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/backends/SFCCCors.js
+++ b/src/backends/SFCCCors.js
@@ -8,8 +8,9 @@ export class SFCCCors {
   }
 
   tokenExpired(expires) {
-    const FIVE_MINS = 300000;
-    const expired = new Date().getTime() + FIVE_MINS;
+    // Count a token as expired some time before its true expiry time, so that it doesn't expire during use.
+    const EXPIRY_BIAS = 300000; // 5 minutes in milliseconds.
+    const expired = new Date().getTime() + EXPIRY_BIAS;
     return expired > expires;
   }
 

--- a/src/backends/SFCCReal.js
+++ b/src/backends/SFCCReal.js
@@ -1,0 +1,166 @@
+import qs from 'qs';
+import { trimEnd } from 'lodash';
+import { ProductSelectorError } from '../ProductSelectorError';
+export class SFCCReal {
+  constructor(settings) {
+    this.settings = settings;
+    this.tokens = {};
+  }
+
+  tokenExpired(expires) {
+    const FIVE_MINS = 300000;
+    const expired = new Date().getTime() + FIVE_MINS;
+    return expired > expires;
+  }  
+
+  async getAuth(state) {
+    const {
+      params: { authSecret, authClientId, sfccUrl: endpoint }
+    } = state;
+    const authUrl = "https://account.demandware.com/dw/oauth2/access_token";
+    const authToken = btoa(authClientId + ':' + authSecret);
+
+    const existingToken = this.tokens[authToken];
+    if (existingToken) {
+      if (this.tokenExpired(existingToken.expires)) {
+        delete this.tokens[authToken];
+      } else {
+        return existingToken.token;
+      }
+    }
+
+    const params = {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + authToken,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: 'grant_type=client_credentials'
+    };
+    const response = await fetch(authUrl, params);
+    if (!response.ok) {
+      throw new Error('Error fetching token', await response.text(), response.statusText || 'unknown')
+    }
+    const token = await response.json();
+
+    const ONE_SECOND_IN_MILLISECONDS = 1000;
+    this.tokens[authToken] = {
+      token: token.access_token,
+      expires: new Date().getTime() + (token.expires_in * ONE_SECOND_IN_MILLISECONDS)
+    };
+
+    return token.access_token;
+  }
+
+  getHeaders(state) {
+    const {
+      params: { authSecret, authClientId, sfccUrl: endpoint }
+    } = state;
+    return {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-auth-id': authClientId,
+        'x-auth-secret': authSecret,
+        endpoint
+      }
+    };
+  }
+
+  async getItems(state, ids) {
+    const {
+      params: { siteId: site_id, proxyUrl }
+    } = state;
+    const token = await this.getAuth(state);
+    console.log(token);
+
+    try {
+      const queryString = qs.stringify(
+        {
+          site_id,
+          ids
+        },
+        { arrayFormat: 'brackets' }
+      );
+      const params = {
+        method: 'GET',
+        ...this.getHeaders(state)
+      };
+      params.method = 'GET';
+      const response = await fetch(trimEnd(proxyUrl, '/') + '/products?' + queryString, params);
+      const { items } = await response.json();
+      return items;
+    } catch (e) {
+      console.error(e);
+      throw new ProductSelectorError('Could not get items', ProductSelectorError.codes.GET_SELECTED_ITEMS);
+    }
+  }
+
+  async search(state) {
+    const {
+      searchText,
+      page,
+      selectedCatalog,
+      params: { siteId, proxyUrl, sfccUrl: endpoint }
+    } = state;
+    const emptyResult = { items: [], page: { numPages: 0, curPage: 0, total: 0 } };
+    const token = await this.getAuth(state);
+    console.log(token);
+
+    const query = {
+      bool_query: {
+        must: [
+          {text_query: {fields: ['id', 'name'], search_phrase: searchText}},
+          {term_query: {fields: ['catalog_id'], operator: 'is', values: selectedCatalog ? [selectedCatalog] : []}}
+        ]
+      }
+    };
+
+    const apiPath = '/s/-/dw/data/v19_10';
+
+    const uri = endpoint + apiPath + '/product_search?site_id='+siteId;
+
+    const params = {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + token,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        query,
+        start: 0,
+        count: 20,
+        expand: ['images'],
+        select : '(**)'
+      })
+    };
+
+    const response = await fetch(uri, params);
+    console.log(await response.json());
+
+    try {
+      const body = {
+        site_id: siteId,
+        search_text: searchText,
+        page: page.curPage
+      };
+
+      if (selectedCatalog !== null) {
+        body.catalog_id = selectedCatalog;
+      }
+      const params = {
+        method: 'POST',
+        body: JSON.stringify(body),
+        ...this.getHeaders(state)
+      };
+      const response = await fetch(trimEnd(proxyUrl, '/') + '/product-search', params);
+      return response.json() || emptyResult;
+    } catch (e) {
+      console.error(e);
+      throw new ProductSelectorError('Could not search', ProductSelectorError.codes.GET_ITEMS);
+    }
+  }
+
+  exportItem(item) {
+    return item.id;
+  }
+}

--- a/src/backends/__tests__/SFCCCors.spec.js
+++ b/src/backends/__tests__/SFCCCors.spec.js
@@ -1,0 +1,418 @@
+import { SFCCCors } from '../SFCCCors';
+import { ProductSelectorError } from '../../ProductSelectorError';
+
+describe('SFCCCors', () => {
+  it("getAuth should return a cached token if it isn't yet expired", async () => {
+    const sfcc = new SFCCCors();
+    const THIRTY_MINS = 30 * 60 * 1000;
+
+    sfcc.tokens[btoa('client:secret')] = {
+      token: 'access',
+      expires: Date.now() + THIRTY_MINS,
+    };
+
+    const state = {
+      params: {
+        authSecret: 'secret',
+        authClientId: 'client',
+      },
+    };
+
+    jest.spyOn(global, 'fetch').mockRejectedValue('Should use cached token');
+
+    const result = await sfcc.getAuth(state);
+
+    expect(result).toEqual('access');
+  });
+
+  it('getAuth should fetch a new token if none is present', async () => {
+    const sfcc = new SFCCCors();
+
+    const state = {
+      params: {
+        authSecret: 'secret',
+        authClientId: 'client',
+      },
+    };
+
+    const fetchValue = {
+      access_token: 'access',
+      expires_in: 30 * 60,
+    };
+
+    jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        json: () => fetchValue,
+        ok: true,
+      })
+    );
+
+    const result = await sfcc.getAuth(state);
+
+    expect(global.fetch).toBeCalledWith('https://account.demandware.com/dw/oauth2/access_token', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + btoa('client:secret'),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials',
+    });
+    expect(sfcc.tokens[btoa('client:secret')]).toEqual({
+      token: 'access',
+      expires: expect.any(Number),
+    });
+    expect(result).toEqual('access');
+  });
+
+  it('getAuth should fetch a new token if cached is expired', async () => {
+    const sfcc = new SFCCCors();
+
+    sfcc.tokens[btoa('client:secret')] = {
+      token: 'access',
+      expires: Date.now(),
+    };
+
+    const state = {
+      params: {
+        authSecret: 'secret',
+        authClientId: 'client',
+      },
+    };
+
+    const fetchValue = {
+      access_token: 'access',
+      expires_in: 30 * 60,
+    };
+
+    jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        json: () => fetchValue,
+        ok: true,
+      })
+    );
+
+    const result = await sfcc.getAuth(state);
+
+    expect(global.fetch).toBeCalledWith('https://account.demandware.com/dw/oauth2/access_token', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + btoa('client:secret'),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials',
+    });
+    expect(sfcc.tokens[btoa('client:secret')]).toEqual({
+      token: 'access',
+      expires: expect.any(Number),
+    });
+    expect(result).toEqual('access');
+  });
+
+  it('getAuth should throw if auth response is not ok', async () => {
+    const sfcc = new SFCCCors();
+
+    const state = {
+      params: {
+        authSecret: 'secret',
+        authClientId: 'client',
+      },
+    };
+
+    jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        text: () => 'example failure',
+        statusText: 'Unauthorized',
+        ok: false,
+      })
+    );
+
+    await expect(sfcc.getAuth(state)).rejects.toEqual(
+      new Error('Error fetching token', 'example failure', 'Unauthorized')
+    );
+
+    expect(global.fetch).toBeCalledWith('https://account.demandware.com/dw/oauth2/access_token', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + btoa('client:secret'),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials',
+    });
+    expect(sfcc.tokens[btoa('client:secret')]).toBeUndefined();
+  });
+
+  it('commonSearch should return items fetched from sfcc api', async () => {
+    const sfcc = new SFCCCors();
+
+    const fetchValue = {
+      total: 41,
+      hits: [
+        {
+          id: 'id1',
+          name: { default: '123' },
+          image: { abs_url: 'imageUrl' },
+        },
+      ],
+    };
+
+    const returnValue = {
+      items: [{ id: 'id1', name: '123', image: 'imageUrl' }],
+      page: { numPages: 3, curPage: 2, total: 41 },
+    };
+
+    jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        json: () => fetchValue,
+      })
+    );
+
+    jest.spyOn(sfcc, 'getAuth').mockImplementation(() => Promise.resolve('testToken'));
+
+    const state = {
+      searchText: 'hello',
+      page: { curPage: 2 },
+      selectedCatalog: 'spa',
+      PAGE_SIZE: 20,
+      params: {
+        siteId: 'siteId',
+        authSecret: 'secret',
+        authClientId: 'client',
+        sfccUrl: 'http://sfcc',
+        sfccVersion: 'vTE_ST',
+      },
+    };
+
+    const result = await sfcc.commonSearch(state, { example: 'query' });
+
+    expect(global.fetch).toBeCalledWith('http://sfcc/s/-/dw/data/vTE_ST/product_search?site_id=siteId', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer testToken',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: { example: 'query' },
+        start: 40,
+        count: 20,
+        expand: ['images'],
+        select: '(**)',
+      }),
+    });
+    expect(sfcc.getAuth).toBeCalledWith(state);
+    expect(result).toEqual(returnValue);
+  });
+
+  it('commonSearch should return empty search if no items returned', async () => {
+    const sfcc = new SFCCCors();
+
+    const returnValue = null;
+
+    jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        json: () => returnValue,
+      })
+    );
+
+    jest.spyOn(sfcc, 'getAuth').mockImplementation(() => Promise.resolve('testToken'));
+
+    const state = {
+      searchText: 'hello',
+      page: { curPage: 2 },
+      selectedCatalog: 'spa',
+      PAGE_SIZE: 20,
+      params: {
+        siteId: 'siteId',
+        authSecret: 'secret',
+        authClientId: 'client',
+        sfccUrl: 'http://sfcc',
+      },
+    };
+
+    const result = await sfcc.commonSearch(state, { example: 'query' });
+
+    expect(global.fetch).toBeCalledWith('http://sfcc/s/-/dw/data/v21_10/product_search?site_id=siteId', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer testToken',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: { example: 'query' },
+        start: 40,
+        count: 20,
+        expand: ['images'],
+        select: '(**)',
+      }),
+    });
+    expect(sfcc.getAuth).toBeCalledWith(state);
+    expect(result).toEqual({
+      items: [],
+      page: { numPages: 0, curPage: 0, total: 0 },
+    });
+  });
+
+  it('getItems should call commonSearch with a term query containing the ids', async () => {
+    const sfcc = new SFCCCors();
+
+    const returnValue = {
+      items: [{ id1: '123', id2: '456' }],
+      page: { numPages: 1, curPage: 0, total: 25 },
+    };
+
+    const state = {
+      searchText: 'hello',
+      page: { curPage: 2 },
+      params: {
+        siteId: 'siteId',
+        authSecret: 'secret',
+        authClientId: 'client',
+        sfccUrl: 'http://sfcc',
+      },
+    };
+
+    const expectedQuery = {
+      term_query: {
+        fields: ['id'],
+        operator: 'one_of',
+        values: ['id1', 'id2'],
+      },
+    };
+
+    jest.spyOn(sfcc, 'commonSearch').mockImplementation(() => Promise.resolve(returnValue));
+
+    const result = await sfcc.getItems(state, ['id1', 'id2']);
+
+    expect(sfcc.commonSearch).toBeCalledWith(state, expectedQuery);
+    expect(result).toEqual(returnValue.items);
+  });
+
+  it('getItems should call commonSearch with a term query containing the ids', async () => {
+    const sfcc = new SFCCCors();
+
+    const returnValue = {
+      items: [{ id1: '123', id2: '456' }],
+      page: { numPages: 1, curPage: 0, total: 25 },
+    };
+
+    const state = {
+      page: { curPage: 2 },
+      params: {
+        siteId: 'siteId',
+        authSecret: 'secret',
+        authClientId: 'client',
+        sfccUrl: 'http://sfcc',
+      },
+    };
+
+    const expectedQuery = {
+      term_query: {
+        fields: ['id'],
+        operator: 'one_of',
+        values: ['id1', 'id2'],
+      },
+    };
+
+    jest.spyOn(sfcc, 'commonSearch').mockImplementation(() => Promise.resolve(returnValue));
+
+    const result = await sfcc.getItems(state, ['id1', 'id2']);
+
+    expect(sfcc.commonSearch).toBeCalledWith(state, expectedQuery);
+    expect(result).toEqual(returnValue.items);
+  });
+
+  it('getItems should log and throw error if failed', async () => {
+    const sfcc = new SFCCCors();
+
+    jest.spyOn(sfcc, 'commonSearch').mockImplementation(() => Promise.reject('Unable to connect'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const state = {
+      page: { curPage: 2 },
+      params: {
+        siteId: 'siteId',
+        authSecret: 'secret',
+        authClientId: 'client',
+        sfccUrl: 'http://sfcc',
+      },
+    };
+
+    try {
+      await sfcc.getItems(state, ['id1', 'id2']);
+    } catch (e) {
+      expect(console.error).toHaveBeenCalledWith('Unable to connect');
+      expect(e).toEqual(new ProductSelectorError('Could not search', ProductSelectorError.codes.GET_SELECTED_ITEMS));
+    }
+  });
+
+  it('search should call commonSearch with a term query containing the ids', async () => {
+    const sfcc = new SFCCCors();
+
+    const returnValue = {
+      items: [{ id1: '123', id2: '456' }],
+      page: { numPages: 1, curPage: 0, total: 25 },
+    };
+
+    const state = {
+      searchText: 'hello',
+      selectedCatalog: 'catalog1',
+      page: { curPage: 2 },
+      params: {
+        siteId: 'siteId',
+        authSecret: 'secret',
+        authClientId: 'client',
+        sfccUrl: 'http://sfcc',
+      },
+    };
+
+    const expectedQuery = {
+      bool_query: {
+        must: [
+          { text_query: { fields: ['id', 'name'], search_phrase: 'hello' } },
+          { term_query: { fields: ['catalog_id'], operator: 'is', values: ['catalog1'] } },
+        ],
+      },
+    };
+
+    jest.spyOn(sfcc, 'commonSearch').mockImplementation(() => Promise.resolve(returnValue));
+
+    const result = await sfcc.search(state);
+
+    expect(sfcc.commonSearch).toBeCalledWith(state, expectedQuery);
+    expect(result).toEqual(returnValue);
+  });
+
+  it('search should log and throw error if failed', async () => {
+    const sfcc = new SFCCCors();
+
+    jest.spyOn(sfcc, 'commonSearch').mockImplementation(() => Promise.reject('Unable to connect'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const state = {
+      searchText: 'hello',
+      page: { curPage: 2 },
+      params: {
+        siteId: 'siteId',
+        authSecret: 'secret',
+        authClientId: 'client',
+        sfccUrl: 'http://sfcc',
+      },
+    };
+
+    try {
+      await sfcc.search(state);
+    } catch (e) {
+      expect(console.error).toHaveBeenCalledWith('Unable to connect');
+      expect(e).toEqual(new ProductSelectorError('Could not search', ProductSelectorError.codes.GET_ITEMS));
+    }
+  });
+
+  it('should export item', async () => {
+    const sfcc = new SFCCCors();
+
+    const result = sfcc.exportItem({
+      id: '480c5acd-a812-41b0-9a6e-b91f23851f36',
+    });
+
+    expect(result).toEqual('480c5acd-a812-41b0-9a6e-b91f23851f36');
+  });
+});

--- a/src/backends/backends.js
+++ b/src/backends/backends.js
@@ -1,11 +1,11 @@
 import {SFCC} from './SFCC';
-import {SFCCReal} from './SFCCReal';
+import {SFCCCors} from './SFCCCors';
 import {Hybris} from './Hybris';
 import {CommerceTools} from './CommerceTools';
 
 export const backends = {
   SFCC: 'sfcc',
-  SFCCDIRECT: 'sfcc-direct',
+  SFCCCORS: 'sfcc-cors',
   HYBRIS: 'hybris',
   COMMERCETOOLS: 'commercetools'
 };
@@ -16,8 +16,8 @@ export const getBackend = (params) => {
       return new Hybris(params);
     case backends.COMMERCETOOLS:
       return new CommerceTools(params);
-    case backends.SFCCDIRECT:
-      return new SFCCReal(params);
+    case backends.SFCCCORS:
+      return new SFCCCors(params);
     case backends.SFCC:
     default:
       return new SFCC(params);

--- a/src/backends/backends.js
+++ b/src/backends/backends.js
@@ -1,9 +1,11 @@
 import {SFCC} from './SFCC';
+import {SFCCReal} from './SFCCReal';
 import {Hybris} from './Hybris';
 import {CommerceTools} from './CommerceTools';
 
 export const backends = {
   SFCC: 'sfcc',
+  SFCCDIRECT: 'sfcc-direct',
   HYBRIS: 'hybris',
   COMMERCETOOLS: 'commercetools'
 };
@@ -14,6 +16,8 @@ export const getBackend = (params) => {
       return new Hybris(params);
     case backends.COMMERCETOOLS:
       return new CommerceTools(params);
+    case backends.SFCCDIRECT:
+      return new SFCCReal(params);
     case backends.SFCC:
     default:
       return new SFCC(params);


### PR DESCRIPTION
This PR adds an SFCC backend that corrects directly to their API, rather than going through a proxy. This is possible when allowing the origin of the extension for CORS from the SFCC configuration, and selecting `allow-same-origin` in the extension permissions list. It behaves similarly to the proxy, except it does all data transformation within the backend.

The only difference in extension side configuration is the omission of the `proxyUrl` param and the backend name `sfcc-cors`.

This doesn't replace the proxied SFCC backend for compatibility reasons. You must manually choose the cors backend.